### PR TITLE
Make menu items sit above the rest of the page

### DIFF
--- a/static/css/shared.css
+++ b/static/css/shared.css
@@ -41,6 +41,7 @@ nav > .container > ul > li {
     display: inline-block;
     margin-left: 0.5rem;
     position: relative;
+    z-index: 100;
 }
 
 nav > .container > ul > li > a {


### PR DESCRIPTION
Before:
![afbeelding](https://github.com/utwente-fmt/vercors-web/assets/2631406/ca8b4308-8d30-4457-a0fa-9ce9e3606d88)

After:
![afbeelding](https://github.com/utwente-fmt/vercors-web/assets/2631406/bcfedf0b-3ef6-45d1-bae6-9cbcf1715340)

There was already a z-index: 100 on the nav element but since that has a fixed position the z-index is ignored.